### PR TITLE
chore(ssl-redirect): using npm module to redirect user to secure site…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4756,9 +4756,9 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
@@ -6131,6 +6131,11 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
+    "heroku-ssl-redirect": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heroku-ssl-redirect/-/heroku-ssl-redirect-0.0.4.tgz",
+      "integrity": "sha1-IboHB6pQO1CkEqCUar+qiO99CCw="
+    },
     "history": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
@@ -6845,9 +6850,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "express": "^4.16.3",
     "express-session": "^1.15.1",
     "file-loader": "^3.0.1",
+    "heroku-ssl-redirect": "0.0.4",
     "history": "^4.6.3",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const sslRedirect = require('heroku-ssl-redirect')
 const express = require('express')
 const morgan = require('morgan')
 const compression = require('compression')
@@ -11,6 +12,9 @@ const PORT = process.env.PORT || 8080
 const app = express()
 const socketio = require('socket.io')
 module.exports = app
+
+// Forcing user to use secure version of site.
+app.use(sslRedirect())
 
 // This is a global Mocha hook, used for resource cleanup.
 // Otherwise, Mocha v4+ never quits after tests.


### PR DESCRIPTION
… - closes #22

Hopefully this will redirect any user that visits our http site to our https site. No way to test it without merging and deploying the change, though!