### PR TITLE
fix(image security error): switched to https source link for "x" image

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -267,7 +267,7 @@ h4 {
   width: 26px;
   height: 26px;
   background: transparent
-    url(http://tympanus.net/Tutorials/CSSOverlay/images/cancel.png) repeat top
+    url(https://tympanus.net/Tutorials/CSSOverlay/images/cancel.png) repeat top
     left;
   margin-top: -30px;
   margin-right: -30px;


### PR DESCRIPTION
Fixed this error: "Loading mixed (insecure) display content “http://tympanus.net/Tutorials/CSSOverlay/images/cancel.png” on a secure page"